### PR TITLE
Support six 1.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import ebcli
 
 requires = ['setuptools>=7.0',
             'pyyaml>=3.11',
-            'six==1.8.0',
+            'six>=1.8.0',
             'cement==2.4',
             ## For botocore we need the following
             'python-dateutil>=2.2',


### PR DESCRIPTION
The AWS CLI and Botocore now depend on `six` version 1.9.0. This allows `awsebcli` to be installed in the same virtualenv as `awscli` and still have it work.