### PR TITLE
Support setting an environment variable which contains =

### DIFF
--- a/ebcli/core/operations.py
+++ b/ebcli/core/operations.py
@@ -851,11 +851,11 @@ def setenv(app_name, env_name, var_list, region):
     options_to_remove = []
     for pair in var_list:
         ## validate
-        if not re.match('^[\w\\_.:/+@-][^=]*=([\w\\_.:/+@-][^=]*)?$', pair):
+        if not re.match('^[\w\\_.:/+@-][^=]*=([\w\\_.:/+@-].*)?$', pair):
             io.log_error(strings['setenv.invalidformat'])
             return
         else:
-            option_name, value = pair.split('=')
+            option_name, value = pair.split('=', 1)
             d = {'Namespace': namespace,
                  'OptionName': option_name}
 


### PR DESCRIPTION
Hi
It would be great if eb would be able to set environment properties which can contain the character "=" as value. Setting such values does work (e.g. by web interface or with this patched eb). Amazon's documentation does even have an [example](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_Java.managing.html) with such a environment property:
> jdbc:mysql://localhost:3306/mydatabase?user=me&password=mypassword
>
>This will be accessible to your Elastic Beanstalk application as a system property called JDBC_CONNECTION_STRING.