### PR TITLE
fix(ebcore): remove finally app.close()

### DIFF
--- a/ebcli/core/ebcore.py
+++ b/ebcli/core/ebcore.py
@@ -138,5 +138,3 @@ def main():
         message = next(io._convert_to_strings([e]))
         io.log_error(e.__class__.__name__ + " :: " + message)
         app.close(code=10)
-    finally:
-        app.close()


### PR DESCRIPTION
It seems to have been catching all invocations, even when errors occur, and
causing the app to close with a standard success status code.

Should fix #12.
