### PR TITLE
Check if the instance is inside a private subnet, and if so use the P…

### DIFF
--- a/ebcli/core/operations.py
+++ b/ebcli/core/operations.py
@@ -1128,7 +1128,12 @@ def ssh_into_instance(instance_id, region, keep_open=False):
     try:
         ip = instance['PublicIpAddress']
     except KeyError:
-        raise NotFoundError(strings['ssh.noip'])
+        # It's possible this instance is in a private subnet, we should see
+        # if it has a PrivateIpAddress and PrivateDnsName
+        if 'PrivateIpAddress' in instance and 'PrivateDnsName' in instance:
+            ip = instance['PrivateDnsName']
+        else:
+            raise NotFoundError(strings['ssh.noip'])
     security_groups = instance['SecurityGroups']
 
 


### PR DESCRIPTION
…rivateDnsName as the IP

By doing this, if the user has setup their SSH config to use ProxyCommand for DNS names ending in `*.ec2.internal`, this transparently supports using `eb ssh -i $INSTANCE_ID` to get to a private instance behind a Bastion Host. I can also add an update to the README about what setup is required (w/r/t to the `~/.ssh/config`) if desired.

Thoughts?