### PR TITLE
Allow --environment to be passed with eb init

### DIFF
--- a/ebcli/controllers/initialize.py
+++ b/ebcli/controllers/initialize.py
@@ -41,6 +41,7 @@ class InitController(AbstractBaseController):
         # get arguments
         self.interactive = self.app.pargs.interactive
         self.region = self.app.pargs.region
+        self.environment = self.app.pargs.environment
         self.flag = False
         if self.app.pargs.platform:
             self.flag = True
@@ -52,6 +53,9 @@ class InitController(AbstractBaseController):
             self.region = self.get_region()
         else:
             self.region = self.get_region_from_inputs()
+
+        if self.environment:
+            default_env = self.environment
 
         self.set_up_credentials()
 

--- a/ebcli/core/ebcore.py
+++ b/ebcli/core/ebcore.py
@@ -79,6 +79,7 @@ class EB(foundation.CementApp):
                      action='store_true', help=flag_text['base.verbose'])
         self.add_arg('--profile', help=flag_text['base.profile'])
         self.add_arg('-r', '--region', help=flag_text['base.region'])
+        self.add_arg('-e', '--environment', help=flag_text['base.environment'])
         self.add_arg('--endpoint-url', help=SUPPRESS)
 
         globals.app = self

--- a/ebcli/resources/strings.py
+++ b/ebcli/resources/strings.py
@@ -81,7 +81,7 @@ strings = {
     'exit.noregion': 'The EB CLI cannot find a default region. Run "eb init" or add the region using the "--region" flag.',
     # Typical response when an environment is in pending state
     'exit.invalidstate': 'The operation cannot be completed at this time due to a pending operation. Try again later.',
-    'branch.noenv': 'This branch does not have a default environment. You must either specify an environment by typing ' 
+    'branch.noenv': 'This branch does not have a default environment. You must either specify an environment by typing '
                     '"eb {cmd} my-env-name" or set a default environment by typing "eb use my-env-name".',
     'ssh.notpresent': 'SSH is not installed. You must install SSH before continuing.',
     'ssh.filenotfound': 'The EB CLI cannot find your SSH key file for keyname "{key-name}".'
@@ -152,6 +152,7 @@ flag_text = {
     'base.verbose': 'toggle verbose output',
     'base.profile': 'use a specific profile from your credential file',
     'base.region': 'use a specific region',
+    'base.environment': 'use a specific environment',
 
     # Clone
     'clone.env': 'name of environment to clone',


### PR DESCRIPTION
`eb init` for an app with multiple environments forces the user to go to interactive mode to select an environment. Would be nice to have the option to pass the default environment so something like Jenkins can run the eb cli.

Currently workaround is to pipe in 1 to select the first environment and then use `eb use` after.

```
echo 1 | eb init my-app --region=eu-west-1
eb use staging-env
```

Cleaner solution could be the ability to pass it as an arg as `eb use` can't be called before `eb init`

```
eb init  my-app --region=eu-west-1 --environment=staging-env
```